### PR TITLE
Fix NPE when running tests in parallel

### DIFF
--- a/src/main/kotlin/io/kotest/extensions/allure/AllureWriter.kt
+++ b/src/main/kotlin/io/kotest/extensions/allure/AllureWriter.kt
@@ -23,6 +23,7 @@ import io.qameta.allure.model.StatusDetails
 import io.qameta.allure.model.StepResult
 import io.qameta.allure.util.ResultsUtils
 import java.lang.reflect.InvocationTargetException
+import java.util.concurrent.ConcurrentHashMap
 import java.util.UUID
 import kotlin.reflect.KClass
 import kotlin.reflect.full.findAnnotation
@@ -44,7 +45,7 @@ class AllureWriter {
       throw t
    }
 
-   private val uuids = mutableMapOf<TestPath, String>()
+   private val uuids = ConcurrentHashMap<TestPath, String>()
 
    fun id(testCase: TestCase) = uuids[testCase.description.testPath()]
 


### PR DESCRIPTION
fixes #5

I guess writing in parallel will destroy the internal state of the map.