### PR TITLE
Remove allure-junit5 dependency and bump gradle to 8.1.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,6 @@ dependencies {
    implementation(libs.kotest.framework.engine)
    implementation(libs.bundles.jaxb)
    api(libs.allure.commons)
-   implementation(libs.allure.junit5)
    testImplementation(libs.kotest.assertions.core)
    testImplementation(libs.kotest.runner.junit5)
    testImplementation(libs.jackson.module.kotlin)
@@ -41,7 +40,14 @@ repositories {
 }
 
 allure {
+   version.set(libs.versions.allure)
    adapter.autoconfigure.set(false)
    adapter.autoconfigureListeners.set(false)
-   version.set(libs.versions.allure)
+   adapter {
+      frameworks {
+         junit5 {
+            enabled.set(false)
+         }
+      }
+   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,6 @@ kotest-framework-engine = { module = "io.kotest:kotest-framework-engine", versio
 jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version = "2.15.0" }
 
 allure-commons = { module = "io.qameta.allure:allure-java-commons", version.ref = "allure" }
-allure-junit5 = { module = "io.qameta.allure:allure-junit5", version.ref = "allure" }
 
 jaxb-api = { module = "javax.xml.bind:jaxb-api", version = "2.3.1" }
 jaxb-core = { module = "com.sun.xml.bind:jaxb-core", version = "4.0.2" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Testing of the snapshot version showed that the allure-junit5 dependency is redundant. I have also bumped the gradle version